### PR TITLE
Bug fixes: Make `check` effective & ban `aesop`

### DIFF
--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -133,7 +133,7 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
       let body := map.source.findAux (· ≠ ' ') tacticRange.start start
 
       -- let checks := suggestions.map fun _ => CheckResult.Unknown
-      println! "check option: {check}"
+      -- println! "check option: {check}"
       let checks := if check then
         ← suggestions.mapM checkSuggestion
       else

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -101,25 +101,25 @@ inductive CheckResult : Type
 /- Check whether the suggestion `s` completes the proof, is valid (does
 not result in an error message), or is invalid. -/
 def checkSuggestion (s: String) : Lean.Elab.Tactic.TacticM CheckResult := do
-  withoutModifyingState do
-  try
-    match Parser.runParserCategory (← getEnv) `tactic s with
-      | Except.ok stx =>
-        try
-          _ ← Lean.Elab.Tactic.evalTactic stx
-          let goals ← Lean.Elab.Tactic.getUnsolvedGoals
-          if (← getThe Core.State).messages.hasErrors then
-            pure CheckResult.Invalid
-          else if goals.isEmpty then
-            pure CheckResult.ProofDone
-          else
-            pure CheckResult.Valid
-        catch _ =>
-          pure CheckResult.Invalid
-      | Except.error _ =>
-        pure CheckResult.Invalid
-  catch _ => pure CheckResult.Invalid
-  -- pure CheckResult.Unknown
+  -- withoutModifyingState do
+  -- try
+  --   match Parser.runParserCategory (← getEnv) `tactic s with
+  --     | Except.ok stx =>
+  --       try
+  --         _ ← Lean.Elab.Tactic.evalTactic stx
+  --         let goals ← Lean.Elab.Tactic.getUnsolvedGoals
+  --         if (← getThe Core.State).messages.hasErrors then
+  --           pure CheckResult.Invalid
+  --         else if goals.isEmpty then
+  --           pure CheckResult.ProofDone
+  --         else
+  --           pure CheckResult.Valid
+  --       catch _ =>
+  --         pure CheckResult.Invalid
+  --     | Except.error _ =>
+  --       pure CheckResult.Invalid
+  -- catch _ => pure CheckResult.Invalid
+  pure CheckResult.Unknown
 
 
 /- Adds multiple suggestions to the Lean InfoView.

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -131,18 +131,26 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
       let start := findLineStart map.source tacticRange.start
       let body := map.source.findAux (· ≠ ' ') tacticRange.start start
 
-      let checks := if check then
-        ← suggestions.mapM checkSuggestion
-      else
-        suggestions.map fun _ => CheckResult.Unknown
+      -- let checks := if check then
+      --   ← suggestions.mapM checkSuggestion
+      -- else
+      --   suggestions.map fun _ => CheckResult.Unknown
+      -- let texts := suggestions.map fun text => (
+      --   (Std.Format.prettyExtra (text.stripSuffix "\n")
+      --    (indent := (body - start).1)
+      --    (column := (tacticRange.start - start).1)
+      -- ))
+
+      -- let textsAndChecks := texts.zip checks |>.toArray |>.qsort
+      --   fun a b => compare a.2 b.2 = Ordering.lt
+
+      let checks := suggestions.map fun _ => CheckResult.Unknown
       let texts := suggestions.map fun text => (
         (Std.Format.prettyExtra (text.stripSuffix "\n")
          (indent := (body - start).1)
          (column := (tacticRange.start - start).1)
       ))
-
-      let textsAndChecks := texts.zip checks |>.toArray |>.qsort
-        fun a b => compare a.2 b.2 = Ordering.lt
+      let textsAndChecks := texts.zip checks |>.toArray
 
       let start := (tacRef.getRange?.getD tacticRange).start
       let stop := (pfxRef.getRange?.getD argRange).stop

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -134,6 +134,7 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
 
       -- let checks := suggestions.map fun _ => CheckResult.Unknown
       -- println! "check option: {check}"
+      logInfo s!"check option: {check}"
       let checks := if check then
         ← suggestions.mapM checkSuggestion
       else

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -168,7 +168,9 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
       --                         "congr", "simp", "rw [sup_inf_left]", "simp only [h]", "exact h _ _ _", "rw [inf_comm]",
       --                         "rw [sup_inf_right]", "rw [sup_inf_left, h]", "simp [h]", "rw [sup_comm]",
       --                         "rw [sup_inf_left, sup_comm]", "congr 1", "simp only [sup_inf_left, h]", "simp_rw [h]", "apply congr_arg", "rw [sup_inf_self]"]
-      let mut suggestions := ["aesop", "simp only [sup_inf_left]", "rw [sup_inf_right, h]", "exact h b c", "rw [sup_inf_sdiff]"]
+      let mut suggestions := ["simp only [sup_inf_left]", "rw [sup_inf_right, h]", "exact h b c", "rw [sup_inf_sdiff]",
+                              "symm", "simp only [sup_inf_right, h]", "ext", "rw [sup_inf_right, sup_comm]",
+                              "rw [sup_inf_left, inf_comm]", "simp_rw [sup_inf_left, h]"]
       let checks ← suggestions.mapM (checkSuggestion check)
 
       -- let mut checks : List CheckResult := []

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -163,7 +163,7 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
       -- let suggestions_with_check := suggestions.map (λ s => (s, check))
       -- let checks ← suggestions_with_check.map checkSuggestion
 
-      let checks ← suggestions.mapM (checkSuggestion check)
+      -- let checks ← suggestions.mapM (checkSuggestion check)
 
       let mut checks : List CheckResult := []
       for suggestion in suggestions do

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -105,6 +105,7 @@ def checkSuggestion (check: Bool) (s: String) : Lean.Elab.Tactic.TacticM CheckRe
   -- let check := s_c.2
   -- logInfo s!"checking suggestion: {s}"
   if check == true then
+    println! s!"checking suggestion: {s}"
     withoutModifyingState do
     try
       match Parser.runParserCategory (← getEnv) `tactic s with
@@ -163,13 +164,17 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
       -- let suggestions_with_check := suggestions.map (λ s => (s, check))
       -- let checks ← suggestions_with_check.map checkSuggestion
 
-      -- let checks ← suggestions.mapM (checkSuggestion check)
+      let mut suggestions := ["rw [sup_inf_self, sup_comm]", "apply h", "rfl", "rw [h]", "apply le_antisymm",
+                              "congr", "simp", "rw [sup_inf_left]", "simp only [h]", "exact h _ _ _", "rw [inf_comm]",
+                              "rw [sup_inf_right]", "rw [sup_inf_left, h]", "simp [h]", "rw [sup_comm]",
+                              "rw [sup_inf_left, sup_comm]", "congr 1", "simp only [sup_inf_left, h]", "simp_rw [h]", "apply congr_arg", "rw [sup_inf_self]"]
+      let checks ← suggestions.mapM (checkSuggestion check)
 
-      let mut checks : List CheckResult := []
-      for suggestion in suggestions do
-        println! s!"checking suggestion: {suggestion}"
-        let result ← checkSuggestion check suggestion
-        checks := result :: checks
+      -- let mut checks : List CheckResult := []
+      -- for suggestion in suggestions do
+      --   println! s!"checking suggestion: {suggestion}"
+      --   let result ← checkSuggestion check suggestion
+      --   checks := result :: checks
 
       -- let checks := if check then
       --   ← suggestions.mapM checkSuggestion

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -98,7 +98,6 @@ inductive CheckResult : Type
 not result in an error message), or is invalid. -/
 def checkSuggestion (check: Bool) (s: String) : Lean.Elab.Tactic.TacticM CheckResult := do
   if check == true then
-    println! s!"checking suggestion: {s}"
     withoutModifyingState do
     try
       match Parser.runParserCategory (← getEnv) `tactic s with

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -103,7 +103,7 @@ not result in an error message), or is invalid. -/
 def checkSuggestion (check: Bool) (s: String) : Lean.Elab.Tactic.TacticM CheckResult := do
   -- let s := s_c.1
   -- let check := s_c.2
-  logInfo s!"checking suggestion: {s}"
+  -- logInfo s!"checking suggestion: {s}"
   if check == true then
     withoutModifyingState do
     try
@@ -162,7 +162,15 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
       -- Append 'check' to each entry in suggestions and form a list of pairs
       -- let suggestions_with_check := suggestions.map (λ s => (s, check))
       -- let checks ← suggestions_with_check.map checkSuggestion
+
       let checks ← suggestions.mapM (checkSuggestion check)
+
+      let mut checks : List CheckResult := []
+      for suggestion in suggestions do
+        logInfo s!"checking suggestion: {suggestion}"
+        let result ← checkSuggestion check suggestion
+        checks := result :: checks
+
       -- let checks := if check then
       --   ← suggestions.mapM checkSuggestion
       -- else

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -168,9 +168,10 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
       --                         "congr", "simp", "rw [sup_inf_left]", "simp only [h]", "exact h _ _ _", "rw [inf_comm]",
       --                         "rw [sup_inf_right]", "rw [sup_inf_left, h]", "simp [h]", "rw [sup_comm]",
       --                         "rw [sup_inf_left, sup_comm]", "congr 1", "simp only [sup_inf_left, h]", "simp_rw [h]", "apply congr_arg", "rw [sup_inf_self]"]
-      let mut suggestions := ["simp only [sup_inf_left]", "rw [sup_inf_right, h]", "exact h b c", "rw [sup_inf_sdiff]",
-                              "symm", "simp only [sup_inf_right, h]", "ext", "rw [sup_inf_right, sup_comm]",
-                              "rw [sup_inf_left, inf_comm]", "simp_rw [sup_inf_left, h]"]
+      -- let mut suggestions := ["simp only [sup_inf_left]", "rw [sup_inf_right, h]", "exact h b c", "rw [sup_inf_sdiff]",
+      --                         "symm", "simp only [sup_inf_right, h]", "ext", "rw [sup_inf_right, sup_comm]",
+      --                         "rw [sup_inf_left, inf_comm]", "simp_rw [sup_inf_left, h]"]
+      let mut suggestions := ["aesop"]
       let checks ← suggestions.mapM (checkSuggestion check)
 
       -- let mut checks : List CheckResult := []

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -131,26 +131,27 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
       let start := findLineStart map.source tacticRange.start
       let body := map.source.findAux (· ≠ ' ') tacticRange.start start
 
+      let checks := suggestions.map fun _ => CheckResult.Unknown
       -- let checks := if check then
       --   ← suggestions.mapM checkSuggestion
       -- else
       --   suggestions.map fun _ => CheckResult.Unknown
-      -- let texts := suggestions.map fun text => (
-      --   (Std.Format.prettyExtra (text.stripSuffix "\n")
-      --    (indent := (body - start).1)
-      --    (column := (tacticRange.start - start).1)
-      -- ))
-
-      -- let textsAndChecks := texts.zip checks |>.toArray |>.qsort
-      --   fun a b => compare a.2 b.2 = Ordering.lt
-
-      let checks := suggestions.map fun _ => CheckResult.Unknown
       let texts := suggestions.map fun text => (
         (Std.Format.prettyExtra (text.stripSuffix "\n")
          (indent := (body - start).1)
          (column := (tacticRange.start - start).1)
       ))
-      let textsAndChecks := texts.zip checks |>.toArray
+
+      let textsAndChecks := texts.zip checks |>.toArray |>.qsort
+        fun a b => compare a.2 b.2 = Ordering.lt
+
+      -- let checks := suggestions.map fun _ => CheckResult.Unknown
+      -- let texts := suggestions.map fun text => (
+      --   (Std.Format.prettyExtra (text.stripSuffix "\n")
+      --    (indent := (body - start).1)
+      --    (column := (tacticRange.start - start).1)
+      -- ))
+      -- let textsAndChecks := texts.zip checks |>.toArray
 
       let start := (tacRef.getRange?.getD tacticRange).start
       let stop := (pfxRef.getRange?.getD argRange).stop

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -101,25 +101,25 @@ inductive CheckResult : Type
 /- Check whether the suggestion `s` completes the proof, is valid (does
 not result in an error message), or is invalid. -/
 def checkSuggestion (s: String) : Lean.Elab.Tactic.TacticM CheckResult := do
-  -- withoutModifyingState do
-  -- try
-  --   match Parser.runParserCategory (← getEnv) `tactic s with
-  --     | Except.ok stx =>
-  --       try
-  --         _ ← Lean.Elab.Tactic.evalTactic stx
-  --         let goals ← Lean.Elab.Tactic.getUnsolvedGoals
-  --         if (← getThe Core.State).messages.hasErrors then
-  --           pure CheckResult.Invalid
-  --         else if goals.isEmpty then
-  --           pure CheckResult.ProofDone
-  --         else
-  --           pure CheckResult.Valid
-  --       catch _ =>
-  --         pure CheckResult.Invalid
-  --     | Except.error _ =>
-  --       pure CheckResult.Invalid
-  --   catch _ => pure CheckResult.Invalid
-  pure CheckResult.Unknown
+  withoutModifyingState do
+  try
+    match Parser.runParserCategory (← getEnv) `tactic s with
+      | Except.ok stx =>
+        try
+          _ ← Lean.Elab.Tactic.evalTactic stx
+          let goals ← Lean.Elab.Tactic.getUnsolvedGoals
+          if (← getThe Core.State).messages.hasErrors then
+            pure CheckResult.Invalid
+          else if goals.isEmpty then
+            pure CheckResult.ProofDone
+          else
+            pure CheckResult.Valid
+        catch _ =>
+          pure CheckResult.Invalid
+      | Except.error _ =>
+        pure CheckResult.Invalid
+  catch _ => pure CheckResult.Invalid
+  -- pure CheckResult.Unknown
 
 
 /- Adds multiple suggestions to the Lean InfoView.
@@ -133,6 +133,7 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
       let body := map.source.findAux (· ≠ ' ') tacticRange.start start
 
       -- let checks := suggestions.map fun _ => CheckResult.Unknown
+      println! "check option: {check}"
       let checks := if check then
         ← suggestions.mapM checkSuggestion
       else

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -167,7 +167,7 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
 
       let mut checks : List CheckResult := []
       for suggestion in suggestions do
-        logInfo s!"checking suggestion: {suggestion}"
+        println! s!"checking suggestion: {suggestion}"
         let result ← checkSuggestion check suggestion
         checks := result :: checks
 

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -164,10 +164,11 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
       -- let suggestions_with_check := suggestions.map (λ s => (s, check))
       -- let checks ← suggestions_with_check.map checkSuggestion
 
-      let mut suggestions := ["rw [sup_inf_self, sup_comm]", "apply h", "rfl", "rw [h]", "apply le_antisymm",
-                              "congr", "simp", "rw [sup_inf_left]", "simp only [h]", "exact h _ _ _", "rw [inf_comm]",
-                              "rw [sup_inf_right]", "rw [sup_inf_left, h]", "simp [h]", "rw [sup_comm]",
-                              "rw [sup_inf_left, sup_comm]", "congr 1", "simp only [sup_inf_left, h]", "simp_rw [h]", "apply congr_arg", "rw [sup_inf_self]"]
+      -- let mut suggestions := ["rw [sup_inf_self, sup_comm]", "apply h", "rfl", "rw [h]", "apply le_antisymm",
+      --                         "congr", "simp", "rw [sup_inf_left]", "simp only [h]", "exact h _ _ _", "rw [inf_comm]",
+      --                         "rw [sup_inf_right]", "rw [sup_inf_left, h]", "simp [h]", "rw [sup_comm]",
+      --                         "rw [sup_inf_left, sup_comm]", "congr 1", "simp only [sup_inf_left, h]", "simp_rw [h]", "apply congr_arg", "rw [sup_inf_self]"]
+      let mut suggestions := ["aesop", "simp only [sup_inf_left]", "rw [sup_inf_right, h]", "exact h b c", "rw [sup_inf_sdiff]"]
       let checks ← suggestions.mapM (checkSuggestion check)
 
       -- let mut checks : List CheckResult := []

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -103,6 +103,7 @@ not result in an error message), or is invalid. -/
 def checkSuggestion (check: Bool) (s: String) : Lean.Elab.Tactic.TacticM CheckResult := do
   -- let s := s_c.1
   -- let check := s_c.2
+  logInfo s!"checking suggestion: {s}"
   if check == true then
     withoutModifyingState do
     try

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -171,7 +171,8 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
       -- let mut suggestions := ["simp only [sup_inf_left]", "rw [sup_inf_right, h]", "exact h b c", "rw [sup_inf_sdiff]",
       --                         "symm", "simp only [sup_inf_right, h]", "ext", "rw [sup_inf_right, sup_comm]",
       --                         "rw [sup_inf_left, inf_comm]", "simp_rw [sup_inf_left, h]"]
-      let mut suggestions := ["aesop"]
+      -- let mut suggestions := ["aesop"]
+
       let checks ← suggestions.mapM (checkSuggestion check)
 
       -- let mut checks : List CheckResult := []

--- a/LeanInfer/Frontend.lean
+++ b/LeanInfer/Frontend.lean
@@ -134,7 +134,7 @@ def addSuggestions (tacRef : Syntax) (pfxRef: Syntax) (suggestions: List String)
 
       -- let checks := suggestions.map fun _ => CheckResult.Unknown
       -- println! "check option: {check}"
-      logInfo s!"check option: {check}"
+      -- logInfo s!"check option: {check}"
       let checks := if check then
         ← suggestions.mapM checkSuggestion
       else

--- a/LeanInfer/Tactics.lean
+++ b/LeanInfer/Tactics.lean
@@ -72,7 +72,9 @@ elab_rules : tactic
     let (tacticsWithScores, elapsed) ← Aesop.time $ suggestTactics pfx.getString
     if ← isVerbose then
       logInfo s!"{elapsed.printAsMillis} for generating {tacticsWithScores.size} tactics"
+    logInfo s!"Step 1: \n{tacticsWithScores}"
     let tactics := tacticsWithScores.map (·.1)
+    logInfo s!"Step 2: \n{tactics}"
     addSuggestions tac pfx tactics.toList (← checkTactics)
 
   | `(tactic | select_premises) => do

--- a/LeanInfer/Tactics.lean
+++ b/LeanInfer/Tactics.lean
@@ -93,6 +93,7 @@ elab_rules : tactic
     logInfo s!"Step 2\n"
     let tactics := tacticsWithScores.map (·.1)
     logInfo s!"Step 3: \n{tactics}"
+    logInfo s!"Step 4: \n{(← checkTactics)}"
     -- addSuggestions tac pfx tactics.toList (← checkTactics)
 
   | `(tactic | select_premises) => do

--- a/LeanInfer/Tactics.lean
+++ b/LeanInfer/Tactics.lean
@@ -83,6 +83,7 @@ elab_rules : tactic
     let tactics := tacticsWithScores.map (·.1)
     logInfo s!"Step 3: \n{tactics}"
     addSuggestions tac pfx tactics.toList (← checkTactics)
+    logInfo s!"Step 4: \n{(← checkTactics)}"
 
   | `(tactic | suggest_tactics_weak%$tac $pfx:str) => do
     logInfo s!"Step 0: ¬Generating tactics for prefix {pfx}"

--- a/LeanInfer/Tactics.lean
+++ b/LeanInfer/Tactics.lean
@@ -51,15 +51,10 @@ syntax "pp_state" : tactic
 syntax "suggest_tactics" : tactic
 syntax "suggest_tactics" str : tactic
 syntax "select_premises" : tactic
-syntax "suggest_tactics_weak" : tactic
-syntax "suggest_tactics_weak" str : tactic
 
 
 macro_rules
   | `(tactic | suggest_tactics%$tac) => `(tactic | suggest_tactics%$tac "")
-
-macro_rules
-  | `(tactic | suggest_tactics_weak%$tac) => `(tactic | suggest_tactics_weak%$tac "")
 
 
 elab_rules : tactic
@@ -74,28 +69,11 @@ elab_rules : tactic
     logInfo state
 
   | `(tactic | suggest_tactics%$tac $pfx:str) => do
-    logInfo s!"Step 0: Generating tactics for prefix {pfx}"
     let (tacticsWithScores, elapsed) ← Aesop.time $ suggestTactics pfx.getString
-    logInfo s!"Step 1: \n{tacticsWithScores}"
     if ← isVerbose then
       logInfo s!"{elapsed.printAsMillis} for generating {tacticsWithScores.size} tactics"
-    logInfo s!"Step 2\n"
     let tactics := tacticsWithScores.map (·.1)
-    logInfo s!"Step 3: \n{tactics}"
     addSuggestions tac pfx tactics.toList (← checkTactics)
-    logInfo s!"Step 4: \n{(← checkTactics)}"
-
-  | `(tactic | suggest_tactics_weak%$tac $pfx:str) => do
-    logInfo s!"Step 0: ¬Generating tactics for prefix {pfx}"
-    let (tacticsWithScores, elapsed) ← Aesop.time $ suggestTactics pfx.getString
-    logInfo s!"Step 1: \n{tacticsWithScores}"
-    if ← isVerbose then
-      logInfo s!"{elapsed.printAsMillis} for generating {tacticsWithScores.size} tactics"
-    logInfo s!"Step 2\n"
-    let tactics := tacticsWithScores.map (·.1)
-    logInfo s!"Step 3: \n{tactics}"
-    logInfo s!"Step 4: \n{(← checkTactics)}"
-    -- addSuggestions tac pfx tactics.toList (← checkTactics)
 
   | `(tactic | select_premises) => do
     let premisesWithScores ← selectPremises

--- a/LeanInfer/Tactics.lean
+++ b/LeanInfer/Tactics.lean
@@ -51,6 +51,8 @@ syntax "pp_state" : tactic
 syntax "suggest_tactics" : tactic
 syntax "suggest_tactics" str : tactic
 syntax "select_premises" : tactic
+syntax "suggest_tactics_weak" : tactic
+syntax "suggest_tactics_weak" str : tactic
 
 
 macro_rules
@@ -78,6 +80,17 @@ elab_rules : tactic
     let tactics := tacticsWithScores.map (·.1)
     logInfo s!"Step 3: \n{tactics}"
     addSuggestions tac pfx tactics.toList (← checkTactics)
+
+  | `(tactic | suggest_tactics_weak%$tac $pfx:str) => do
+    logInfo s!"Step 0: ¬Generating tactics for prefix {pfx}"
+    let (tacticsWithScores, elapsed) ← Aesop.time $ suggestTactics pfx.getString
+    logInfo s!"Step 1: \n{tacticsWithScores}"
+    if ← isVerbose then
+      logInfo s!"{elapsed.printAsMillis} for generating {tacticsWithScores.size} tactics"
+    logInfo s!"Step 2\n"
+    let tactics := tacticsWithScores.map (·.1)
+    logInfo s!"Step 3: \n{tactics}"
+    -- addSuggestions tac pfx tactics.toList (← checkTactics)
 
   | `(tactic | select_premises) => do
     let premisesWithScores ← selectPremises

--- a/LeanInfer/Tactics.lean
+++ b/LeanInfer/Tactics.lean
@@ -58,6 +58,9 @@ syntax "suggest_tactics_weak" str : tactic
 macro_rules
   | `(tactic | suggest_tactics%$tac) => `(tactic | suggest_tactics%$tac "")
 
+macro_rules
+  | `(tactic | suggest_tactics_weak%$tac) => `(tactic | suggest_tactics_weak%$tac "")
+
 
 elab_rules : tactic
   | `(tactic | trace_generate $input:str) => do

--- a/LeanInfer/Tactics.lean
+++ b/LeanInfer/Tactics.lean
@@ -74,7 +74,7 @@ elab_rules : tactic
     logInfo state
 
   | `(tactic | suggest_tactics%$tac $pfx:str) => do
-    logInfo s!"Step 0: ¬Generating tactics for prefix {pfx}"
+    logInfo s!"Step 0: Generating tactics for prefix {pfx}"
     let (tacticsWithScores, elapsed) ← Aesop.time $ suggestTactics pfx.getString
     logInfo s!"Step 1: \n{tacticsWithScores}"
     if ← isVerbose then

--- a/LeanInfer/Tactics.lean
+++ b/LeanInfer/Tactics.lean
@@ -69,12 +69,14 @@ elab_rules : tactic
     logInfo state
 
   | `(tactic | suggest_tactics%$tac $pfx:str) => do
+    logInfo s!"Step 0: ¬Generating tactics for prefix {pfx}"
     let (tacticsWithScores, elapsed) ← Aesop.time $ suggestTactics pfx.getString
+    logInfo s!"Step 1: \n{tacticsWithScores}"
     if ← isVerbose then
       logInfo s!"{elapsed.printAsMillis} for generating {tacticsWithScores.size} tactics"
-    logInfo s!"Step 1: \n{tacticsWithScores}"
+    logInfo s!"Step 2\n"
     let tactics := tacticsWithScores.map (·.1)
-    logInfo s!"Step 2: \n{tactics}"
+    logInfo s!"Step 3: \n{tactics}"
     addSuggestions tac pfx tactics.toList (← checkTactics)
 
   | `(tactic | select_premises) => do


### PR DESCRIPTION
# Bug fixes

## Make `check` option effective

This PR makes the `LeanInfer.suggest_tactics.check` option effective, which enables/disables the check of whether the generated tactics are valid or whether they can prove the goal.

## Ban `aesop`

Especially when `llmaesop` is enabled by the user, it would be problematic if the model returns `aesop` as a tactic suggestion, which leads to the checking process hanging forever. We thus ban `aesop` from being generated for either `suggest_tactics` or `llmaesop`.